### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like that you're using Pydantic to define data structures for an AI Diplomacy game, which suggests a focus on type safety and maintainability. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] Pydantic AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
   What it means: The project uses Pydantic AI in code but ships no agent-guidance doc (AGENTS.md or CLAUDE.md). A well-documented agent guidance strategy is crucial for ensuring consistent and predictable behavior from the AI agents.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)